### PR TITLE
Add a custom sink for machine learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/*
 spark-warehouse/*
 project/project/*
 project/target/*
+checkpoint/
 .idea

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Structured Streaming and Machine learning
+
+## Run the Project
+```
+sbt run
+```
+
+## Requirements
+* Kafka with a topic `test`

--- a/src/main/scala/SparkApp.scala
+++ b/src/main/scala/SparkApp.scala
@@ -17,7 +17,8 @@ trait SparkApp extends App {
     .config("spark.driver.memory", "200g")
     .config("spark.executor.extraJavaOptions", "-XX:-UseGCOverheadLimit")
     .config("spark.network.timeout", "60s")
-      .config("spark.executor.heartbeatInterval", "100s")
+    .config("spark.executor.heartbeatInterval", "100s")
+    .config("spark.sql.streaming.checkpointLocation", "checkpoint")
     .getOrCreate()
 
   spark.conf.set("spark.memory.fraction", ".9")

--- a/src/main/scala/streaming/RegressionSink.scala
+++ b/src/main/scala/streaming/RegressionSink.scala
@@ -1,0 +1,29 @@
+package streaming
+
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.sql.execution.streaming.Sink
+
+class RegressionSink() extends Sink with LazyLogging {
+  private val spark =  SparkSession
+    .builder()
+    .getOrCreate()
+
+  import spark.implicits._
+  import org.apache.spark.sql.functions._
+
+  private def modelMethod(df: DataFrame) = {
+    logger.error(s"modelMethod -  df.count() : ${df.count()}")
+    df.show()
+  }
+
+  /*
+   * As per SPARK-16020 arbitrary transformations are not supported, but
+   * converting to an RDD allows us to do magic.
+   */
+  override def addBatch(batchId: Long, df: DataFrame) = {
+    logger.error(s"RegressionSink -  batchId : ${batchId}")
+    modelMethod(df)
+  }
+}
+

--- a/src/main/scala/streaming/RegressionSinkProvider.scala
+++ b/src/main/scala/streaming/RegressionSinkProvider.scala
@@ -1,0 +1,19 @@
+package streaming
+
+import org.apache.spark.sql.sources.StreamSinkProvider
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.{DataFrame, SQLContext}
+
+/**
+  From Holden Karau's High Performance Spark
+  https://github.com/holdenk/polomarcus.spark-structured-streaming-ml/blob/master/src/main/scala/com/high-performance-polomarcus.spark-examples/structuredstreaming/CustomSink.scala#L66
+  *
+  */
+class RegressionSinkProvider extends StreamSinkProvider {
+  override def createSink(sqlContext: SQLContext,
+                          parameters: Map[String, String],
+                          partitionColumns: Seq[String],
+                          outputMode: OutputMode): RegressionSink = {
+    new RegressionSink()
+  }
+}


### PR DESCRIPTION
Custom sink with ` def modelMethod(df: DataFrame) ` in order to use the model there


Other way to do it : https://hortonworks.com/tutorial/deploying-machine-learning-models-using-spark-structured-streaming/